### PR TITLE
Use popToTop to clean up route stack

### DIFF
--- a/src/NavBar.js
+++ b/src/NavBar.js
@@ -85,9 +85,7 @@ class NavBar extends Component {
     if (!navigator) return
 
     // Clean up old routes after transition
-    if (navigator.getCurrentRoutes().length > 1) {
-      navigator.immediatelyResetRouteStack([route])
-    }
+    navigator.popToTop()
   }
 
   render () {


### PR DESCRIPTION
There's no guarantee that the route just rendered by `_onRouteDidFocus` is still on the top of the stack by the time the transition is complete, so the current implementation will chop off any routes that have been pushed on in the interim without them rendering.  This is particularly a problem after cold boot when the navigator takes a while to warm up and Redux might be rerouting several times in the interim as the store is initialized.

This PR addresses this by using `popToTop`, which resets the stack to be only the *top-most* route, whether that's the route that's just finished rendering or not.