### PR TITLE
Adds dedicated route queue to pass into the navigator sequentially

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tableflip/react-native-navbar",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Stateless NavBar navigation for React Native",
   "main": "src/NavBar.js",
   "dependencies": {

--- a/src/NavBar.js
+++ b/src/NavBar.js
@@ -47,6 +47,7 @@ class NavBar extends Component {
   constructor (props) {
     super(props)
     this._navigator = null
+    this.routeQueue = []
     this.state = {}
 
     const { url, routes } = props
@@ -56,6 +57,7 @@ class NavBar extends Component {
     const route = findRoute(url, routes)
     if (!route) return console.warn(`Route not found "${url}"`)
 
+    this.routeQueue.push(route)
     this.state = { initialRoute: route, initialRouteStack: [route] }
   }
 
@@ -73,21 +75,37 @@ class NavBar extends Component {
     const navigator = this._navigator
     if (!navigator || isSameUrl(nextUrl, url)) return
 
-    if (route.from === 'none') {
-      return navigator.replace(route)
+    // If the queue is empty, give this route to the navigator immediately
+    if (!this.routeQueue.length) {
+      if (route.from === 'none') {
+        navigator.replace(route)
+      } else {
+        navigator.push(route)
+      }
     }
 
-    navigator.push(route)
+    this.routeQueue.push(route)
   }
 
   _onRouteDidFocus = (route) => {
     const navigator = this._navigator
-    if (!navigator) return
+    if (!navigator) return setTimeout(() => this._onRouteDidFocus(route), 1)
 
     // Clean up old routes after transition
-    const currentRoutes = navigator.getCurrentRoutes()
-    const routeIndex = currentRoutes.findIndex(({ url }) => isSameUrl(url, this.props.url))
-    if (routeIndex > 0) navigator.immediatelyResetRouteStack(currentRoutes.slice(routeIndex))
+    this.routeQueue.shift()
+
+    const nextRoute = this.routeQueue[0]
+    if (nextRoute) {
+      const currentRoutes = navigator.getCurrentRoutes()
+      // "shift" the navigator route stack
+      if (currentRoutes.length > 1) navigator.immediatelyResetRouteStack(currentRoutes.slice(1))
+
+      if (nextRoute.from === 'none') {
+        navigator.replace(nextRoute)
+      } else {
+        navigator.push(nextRoute)
+      }
+    }
   }
 
   render () {


### PR DESCRIPTION
The navigator doesn't seem capable of robustly managing its own route queue if several items are pushed onto it in rapid succession.

This maintains a separate route queue, pushing new items into the navigator when the previous one has rendered (if required).  Items are removed from this separate queue as soon as they're rendered.