### PR TITLE
Add isFocusedRoute prop so components can determine if they are the current focus or not

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ The following properties are passed to route components and "navBar" components:
     * `location.query` - a querystring-parsed object
     * `location.hash` - the 'fragment' portion of the URL including the pound-sign
 
+The following additional properties are passed to route components:
+
+* `isFocusedRoute` - whether or not this is the currently focused route (it won't be during transition in/out)
+
 ## Props
 
 ### `routes`

--- a/src/NavBar.js
+++ b/src/NavBar.js
@@ -129,7 +129,12 @@ class NavBar extends Component {
         initialRouteStack={initialRouteStack}
         renderScene={(route) => {
           const Component = route.component
-          return <Component location={route.location} params={route.params} />
+          return (
+            <Component
+              location={route.location}
+              params={route.params}
+              isFocusedRoute={isSameUrl(route.url, this.props.url)} />
+          )
         }}
         configureScene={(route, routeStack) => ({
           ...(route.from === 'left' ? sceneConfigLeft : sceneConfigRight),


### PR DESCRIPTION
Allows nav components to clean up (pause videos) before they are unmounted (which is potentially a while in the future).

Whenever the navigator changes routes, it actually calls `renderScene` for each scene on the stack. This means we can determine if the route for the scene being rendered is for the current URL.