### PR TITLE
Fix memory leak, always clean up routes after transition

### DIFF
--- a/src/NavBar.js
+++ b/src/NavBar.js
@@ -95,15 +95,22 @@ class NavBar extends Component {
     this.routeQueue.shift()
 
     const nextRoute = this.routeQueue[0]
+    const currentRoutes = navigator.getCurrentRoutes()
+
     if (nextRoute) {
-      const currentRoutes = navigator.getCurrentRoutes()
       // "shift" the navigator route stack
-      if (currentRoutes.length > 1) navigator.immediatelyResetRouteStack(currentRoutes.slice(1))
+      if (currentRoutes.length > 1) {
+        navigator.immediatelyResetRouteStack(currentRoutes.slice(1))
+      }
 
       if (nextRoute.from === 'none') {
         navigator.replace(nextRoute)
       } else {
         navigator.push(nextRoute)
+      }
+    } else {
+      if (currentRoutes.length > 1) {
+        navigator.immediatelyResetRouteStack([route])
       }
     }
   }


### PR DESCRIPTION
Bug arose from the changes here https://github.com/tableflip/react-native-navbar/compare/d932946a106eff91a7e63b23a9de30e7a12fd5ea...16820eaa469d5d85f08613c002aee162121271d2

Basically if there's no items in the queue then the route that has just transitioned out of view doesn't get removed from the route stack.